### PR TITLE
Repo tidy-up + README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Keep the build context small. Mirrors .gcloudignore.
+# NOTE: do NOT exclude requirements.txt, setup.py, fast_api/, project_logic/ or models/ —
+# the image needs them to `pip install -e .` and to load the trained pipeline.
+
+.git
+.gitignore
+.gcloudignore
+.dockerignore
+
+# Local env / tooling
+.env
+.envrc
+.python-version
+.claude/
+
+# Notebooks and data are not needed at runtime
+notebooks/
+raw_data/
+*.csv
+*.sqlite
+*.zip
+
+# Python / OS cruft
+__pycache__/
+*.pyc
+*.egg-info/
+.ipynb_checkpoints/
+.coverage
+.DS_Store
+*Zone.Identifier

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,16 @@ models/
 .env.yaml
 .credentials
 secrets.toml
-*.json
+# GCP service-account keys and other credential JSON (scoped — a blanket
+# *.json rule also hides legitimate config files, so only ignore key-like ones)
+*-key.json
+*-keyfile.json
+*credentials*.json
+service-account*.json
+gcp-*.json
+
+# Notebook scratch artifacts (intermediate models / configs dumped next to a notebook)
+notebooks/*.json
 
 #Claude
 .claude/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,158 @@
 # VenturePulse
-repository for our final project at Le Wagon
+
+Predict whether a startup will **survive or shut down** from its funding history — and explain *why*.
+
+VenturePulse trains an XGBoost classifier on Crunchbase venture-funding data, serves predictions through a FastAPI endpoint, and turns the model's SHAP values into plain-English "strengths" and "risks" that a frontend can show directly to a user.
+
+Built as the final project for the Le Wagon Data Science bootcamp.
+
+---
+
+## What it does
+
+Given a company's funding profile (dates, amounts, funding types, region, industry), the API returns:
+
+```jsonc
+{
+  "prediction": "survived",          // or "closed"
+  "confidence": 92.4,                // % confidence in that prediction
+  "survival_probability": 92.4,      // % probability of survival (always)
+  "strengths": [                     // factors pushing toward survival
+    { "label": "Active funding momentum", "impact": "high" },
+    { "label": "Total capital raised",    "impact": "medium" }
+  ],
+  "risks": [                         // factors pushing toward closure
+    { "label": "Long gaps between funding rounds", "impact": "low" }
+  ]
+}
+```
+
+Under the hood:
+
+- **Model** — a scikit-learn `Pipeline` (`prep` ColumnTransformer + XGBoost classifier) saved to `models/best_pipeline_bin_death_score.pkl`.
+- **Data** — the Kaggle Crunchbase "investments_VC" dataset, enriched with up-to-date operating status from the HuggingFace `opensporks/crunchbase` dataset (Aug 2024 snapshot). See `raw_data/enrich_status.py`.
+- **Explainability** — `shap.TreeExplainer` over the XGBoost model; `project_logic/shap_translator.py` converts raw log-odds SHAP values into human-readable labels and impact levels.
+
+---
+
+## Repository layout
+
+```
+.
+├── fast_api/
+│   └── app.py                 # FastAPI app: GET / (health), GET /predict
+├── project_logic/
+│   ├── registry.py            # save/load the trained pipeline (models/*.pkl)
+│   ├── predict.py             # thin predict_proba wrapper
+│   └── shap_translator.py     # SHAP values -> {strengths, risks} JSON
+├── raw_data/
+│   └── enrich_status.py       # enrich investments_VC.csv with HF status data
+├── models/                    # trained pipeline artifact(s)  (git-ignored)
+├── notebooks/                 # data cleaning, EDA, feature engineering, modeling, SHAP
+├── Dockerfile
+├── Makefile
+├── requirements.txt
+├── setup.py
+└── .env_sample
+```
+
+> **Note:** `models/`, `raw_data/` and most data files are git-ignored. You need the trained
+> `best_pipeline_bin_death_score.pkl` in `models/` before the API will start — ask a maintainer
+> for the artifact, or retrain it from the modeling notebooks.
+
+---
+
+## Getting started
+
+Requires **Python 3.10**.
+
+```bash
+# 1. Create / activate a virtual environment (pyenv example)
+pyenv virtualenv 3.10 venturepulse
+pyenv local venturepulse
+
+# 2. Install dependencies + the package (editable)
+pip install -r requirements.txt
+pip install -e .
+
+# 3. Provide the trained model
+#    Put best_pipeline_bin_death_score.pkl into ./models/
+
+# 4. Run the API
+make run_api          # uvicorn fast_api.app:app --reload --port 8080
+```
+
+Then open <http://localhost:8080/docs> for the interactive Swagger UI.
+
+### Example request
+
+```bash
+curl "http://localhost:8080/predict?\
+founded_at=2018-01-01&first_funding_at=2018-09-01&last_funding_at=2021-06-01&\
+funding_total_usd=12000000&funding_rounds=3&\
+seed=1&venture=1&debt_financing=0&angel=0&grant=0&private_equity=0&\
+round_A=1&round_B=1&round_C=0&round_D=0&\
+region_group=USA&industry_group=Software_Data"
+```
+
+`region_group` is one of: `USA`, `EU_UK`, `Canada`, `Australia`, `Asia`, `Rest_World`, `Rest_Americas`, `Unknown`.
+`industry_group` is one of: `Health_Bio`, `Consumer_Internet`, `Software_Data`, `Energy`, `Education`, `Services`, `Real_World`, `Ecommerce`, `FinTech`, `Hardware_DeepTech`, `Unknown`, `Other`.
+
+---
+
+## Docker
+
+```bash
+make docker_build     # docker build -t venturepulse .
+make docker_run       # docker run -p 8080:8080 venturepulse
+```
+
+The container reads `PORT` (defaults to `8080`).
+
+## Deployment (Google Cloud Run)
+
+```bash
+make gcloud_build     # gcloud builds submit --tag gcr.io/<project>/venturepulse
+make gcloud_deploy    # gcloud run deploy venturepulse ... --region europe-west1
+```
+
+> The GCP project id is currently hard-coded in the `Makefile` — update it for your own project.
+
+---
+
+## Data enrichment
+
+To regenerate the enriched dataset from scratch:
+
+```bash
+pip install datasets pandas
+python raw_data/enrich_status.py --input raw_data/investments_VC.csv \
+                                 --output raw_data/enriched_investments.csv
+```
+
+This streams the ~2.8M-row HuggingFace Crunchbase dataset and adds a `status_enriched` column
+(`operating` / `acquired` / `closed`) without touching the original `status` column. Expect 3–5 minutes.
+
+---
+
+## Notebooks
+
+The `notebooks/` directory contains the exploratory and modeling work, roughly in this order:
+
+| Stage | Notebooks |
+|-------|-----------|
+| Data cleaning | `data_cleaning_all.ipynb`, `data_cleaning_enriched.ipynb` |
+| Exploration | `data_exploration_*.ipynb` |
+| Feature engineering | `feature_engineering_enriched_dataset.ipynb`, `label_feature_engineering_cdp.ipynb` |
+| Modeling | `basic_modeling_all.ipynb`, `death_score_model.ipynb`, `modeling_new_targets.ipynb`, `slim_feature_set_model.ipynb`, `final_models_.ipynb` |
+| Explainability | `shap_explainability.ipynb` |
+
+---
+
+## Tech stack
+
+FastAPI · Uvicorn · scikit-learn · XGBoost 1.7.6 · SHAP · pandas · Docker · Google Cloud Run
+
+## Authors
+
+Le Wagon Data Science — final project team.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,23 @@
+# Ruff configuration — https://docs.astral.sh/ruff/
+# Run:  ruff check .        (lint)
+#       ruff check --fix .  (lint + autofix)
+#       ruff format .       (format)
+
+target-version = "py310"
+line-length = 100
+
+# Notebooks contain exploratory code with intentionally loose style; skip them.
+extend-exclude = ["notebooks"]
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort (import ordering)
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+]
+ignore = [
+    "E501",  # line-too-long: the codebase uses aligned-dict formatting on purpose
+]


### PR DESCRIPTION
Housekeeping only — no changes to application code, the Makefile, or the Dockerfile, so the API / Docker run / Cloud Run deploy behave exactly as before.

## Changes

- **Remove accidental nested git repo** — `VenturePulse/` was tracked as a bare gitlink (mode 160000) with no `.gitmodules` mapping: an early clone of this same project committed by mistake. Unreferenced; would break `git clone --recursive`.
- **Add a real README** — replaces the two-line stub. Covers what the project does, the `/predict` response shape, repo layout, local setup, an example request, Docker, Cloud Run deploy, the data-enrichment script, and a notebook index.
- **Add `.dockerignore`** — the Dockerfile does `COPY . .`, so the image was shipping `.git/`, all notebooks, and the nested repo. Mirrors `.gcloudignore`; deliberately keeps `requirements.txt`, `setup.py`, `fast_api/`, `project_logic/`, `models/` which the build/runtime need.
- **Scope the `.gitignore` JSON rule** — the blanket `*.json` ignore silently hid legitimate config files. Replaced with targeted credential patterns (`*-key.json`, `*credentials*.json`, `service-account*.json`, `gcp-*.json`) plus `notebooks/*.json` for scratch artifacts.
- **Add `ruff.toml`** — minimal lint/format config (py310, line-length 100, excludes `notebooks/`, selects `E/W/F/I/UP/B`, ignores `E501`). Nothing runs it automatically.
- Also removed untracked notebook scratch files locally (`notebooks/.ipynb_checkpoints/`, `temp_model.json`, two stray `.pkl`s) — not part of git, just working-tree tidy.

## Deliberately not done
- Renumbering notebooks (`01_…`, `02_…`) — `shap_explainability.ipynb` and `final_models_.ipynb` reference each other by filename in their comments, so renaming would leave stale references.
- Renaming `project_logic/` → `venturepulse/` and `fast_api/` → `api/` — safe but touches imports/Makefile/Dockerfile; left for a separate, smoke-tested PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)